### PR TITLE
Created SQL query to lower cost of Dual Spec to 500g

### DIFF
--- a/apps/wotlk/fixes/sql/reducecostDualSpec.sql
+++ b/apps/wotlk/fixes/sql/reducecostDualSpec.sql
@@ -1,0 +1,1 @@
+UPDATE gossip_menu_option SET BoxMoney = 5000000 WHERE OptionType = 18


### PR DESCRIPTION
This SQL query should update "Gossip Menu Option" Option type 18 (Specific option type for Dual Spec purchase) and set the box money value to 5000000 which should be 500g as box money uses values of copper.